### PR TITLE
Ignore non existent directories

### DIFF
--- a/src/WatcherFactory.php
+++ b/src/WatcherFactory.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\PhpUnitWatcher;
 
+use InvalidArgumentException;
 use Symfony\Component\Finder\Finder;
 
 class WatcherFactory
@@ -9,6 +10,13 @@ class WatcherFactory
     public static function create(array $options = []): array
     {
         $options = static::mergeWithDefaultOptions($options);
+
+        if (empty($options['watch']['directories'])) {
+            throw new InvalidArgumentException(
+                'The watch directories do not exist. Make sure you are running the watcher from '.
+                'the root of your project, or create a custom config file.'
+            );
+        }
 
         $finder = (new Finder())
             ->ignoreDotFiles(false)
@@ -35,6 +43,7 @@ class WatcherFactory
         $options = array_merge([
             'watch' => [
                 'directories' => [
+                    'app',
                     'src',
                     'tests',
                 ],
@@ -43,9 +52,13 @@ class WatcherFactory
             'cache' => '.phpunit-watcher-cache.php',
         ], $options);
 
-        foreach ($options['watch']['directories'] as $index => $directory) {
-            $options['watch']['directories'][$index] = getcwd()."/{$directory}";
-        }
+        $options['watch']['directories'] = array_map(function ($directory) {
+            return getcwd()."/{$directory}";
+        }, $options['watch']['directories']);
+
+        $options['watch']['directories'] = array_filter($options['watch']['directories'], function ($directory) {
+            return file_exists($directory);
+        });
 
         return $options;
     }


### PR DESCRIPTION
This PR fixes #5 by ignoring directories that do not exist. Also, it adds `app/` as a default directory, and shows an error when non of the configured directories exists.

I took the liberty to convert [this foreach](https://github.com/spatie/phpunit-watcher/pull/7/files#diff-4aa14a6c071ed7923d3307996f77ec5cL46) into an `array_map`, to make it more in line with the `array_filter`. Please let me know if you don't like this change.