### PR TITLE
feature/006-support-dotfiles

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `phpunit-watcher` will be documented in this file
 
+## 1.2.0 - 2017-08-05
+
+- check parent directories for config file
+
 ## 1.1.0 - 2017-08-02
 
 - add interactive commands

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ watch:
   fileMask: '*.php'
 ```
 
+If a such a config file does not exist in the project directory, the tool will check if the file exists in any of the parent directories of the project directory.
+
 Want to pass some arguments to PHPUnit no problem, just tack them on:
 
 ```bash

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -41,32 +41,35 @@ class WatcherCommand extends Command
         return $options;
     }
 
-    protected function getOptionsConfigFile()
-    {
-        $configPath = getcwd();
-        $configFile = $configPath . self::PHPUNIT_WATCH_CONFIG_FILENAME;
-
-        while (! file_exists($configFile)):
-            $configPath = dirname($configPath);
-            $configFile = $configPath . self::PHPUNIT_WATCH_CONFIG_FILENAME;
-            if ($configPath === '/') {
-                $configFile = self::PHPUNIT_WATCH_CONFIG_FILENAME;
-                break;
-            }
-        endwhile;
-
-        return $configFile;
-    }
-
     protected function getOptionsFromConfigFile(): array
     {
-        $configFile = $this->getOptionsConfigFile();
+        $configFile = $this->getConfigFileLocation();
 
         if (! file_exists($configFile)) {
             return [];
         }
 
         return Yaml::parse(file_get_contents($configFile));
+    }
+
+    protected function getConfigFileLocation()
+    {
+        $configName = '.phpunit-watcher.yml';
+
+        $configDirectory = getcwd();
+
+        while(is_dir($configDirectory)) {
+            $configFullPath = "{$configDirectory}/{$configName}";
+
+            if (file_exists($configFullPath)) {
+                return $configFullPath;
+            }
+
+            if ($configDirectory === DIRECTORY_SEPARATOR) {
+                return;
+            }
+            $configDirectory = dirname($configDirectory);
+        };
     }
 
     protected function displayOptions(array $options, InputInterface $input, OutputInterface $output)

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -8,9 +8,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function var_dump;
 
 class WatcherCommand extends Command
 {
+    const PHPUNIT_WATCH_CONFIG_FILENAME = "/.phpunit-watcher.yml";
+
     protected function configure()
     {
         $this->setName('watch')
@@ -38,9 +41,26 @@ class WatcherCommand extends Command
         return $options;
     }
 
+    protected function getOptionsConfigFile()
+    {
+        $configPath = getcwd();
+        $configFile = $configPath . self::PHPUNIT_WATCH_CONFIG_FILENAME;
+
+        while (! file_exists($configFile)):
+            $configPath = dirname($configPath);
+            $configFile = $configPath . self::PHPUNIT_WATCH_CONFIG_FILENAME;
+            if ($configPath === '/') {
+                $configFile = self::PHPUNIT_WATCH_CONFIG_FILENAME;
+                break;
+            }
+        endwhile;
+
+        return $configFile;
+    }
+
     protected function getOptionsFromConfigFile(): array
     {
-        $configFile = getcwd().'/.phpunit-watcher.yml';
+        $configFile = $this->getOptionsConfigFile();
 
         if (! file_exists($configFile)) {
             return [];
@@ -55,7 +75,7 @@ class WatcherCommand extends Command
 
         $output->title('PHPUnit Watcher');
 
-        $output->text("Tests will be rerun when {$options['watch']['fileMask']} files are modified in");
+        $output->text("Tests will be rerun when {$options['watch']['fileMask']} files are modified in the following directories:\n");
 
         $output->listing($options['watch']['directories']);
 

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -8,7 +8,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use function var_dump;
 
 class WatcherCommand extends Command
 {

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -78,7 +78,7 @@ class WatcherCommand extends Command
 
         $output->title('PHPUnit Watcher');
 
-        $output->text("Tests will be rerun when {$options['watch']['fileMask']} files are modified in the following directories:\n");
+        $output->text("Tests will be rerun when {$options['watch']['fileMask']} files are modified in");
 
         $output->listing($options['watch']['directories']);
 


### PR DESCRIPTION
- [x] Add support for global `.phpunit-watcher.yml` files up the directory tree
- [x] Once a `.phpunit-watcher.yml` is found, its contents will be used