### PR TITLE
Register listeners after handling a keypress event

### DIFF
--- a/src/Screens/Phpunit.php
+++ b/src/Screens/Phpunit.php
@@ -51,6 +51,9 @@ class Phpunit extends Screen
                 case 'q':
                     die();
                     break;
+                default:
+                    $this->registerListeners();
+                    break;
             }
         });
 


### PR DESCRIPTION
Currently, the application listens to a keypress only once. This causes an issue as described in #38.

After having 'heard' the event, the listeners will be removed. This PR readds those listeners after having pressed an 'unrecognized' key. (note that we cannot simply change the listener from once to always, because this results in handling the same keypress multiple times).

See also an alternative approach in #40.