### PR TITLE
Drop unnecessary path prefix and ignore completion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,16 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
-/tests              export-ignore
-/.editorconfig      export-ignore
+.editorconfig       export-ignore
+.gitattributes      export-ignore
+.gitignore          export-ignore
+.scrutinizer.yml    export-ignore
+.styleci.yml        export-ignore
+.travis.yml         export-ignore
+CHANGELOG.md        export-ignore
+CONTRIBUTING.md     export-ignore
+docs/               export-ignore
+LICENSE.md          export-ignore
+phpunit.xml.dist    export-ignore
+README.md           export-ignore
+tests/              export-ignore


### PR DESCRIPTION
Completed the list of files to exclude from releases/distributions. The `docs` directory and the `LICENSE.md` file might be excluded from that list of files, but that's up to your liking.