### PR TITLE
Add interactive mode filter for PHPUnit groups

### DIFF
--- a/src/Screens/FilterGroupName.php
+++ b/src/Screens/FilterGroupName.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\PhpUnitWatcher\Screens;
+
+class FilterGroupName extends Screen
+{
+    public function draw()
+    {
+        $this->terminal
+            ->comment('Pattern mode usage')
+            ->write('Type a pattern and press Enter to only run tests from a specific PHPUnit group.')
+            ->write('Press Enter with an empty pattern to execute all tests in all files.')
+            ->emptyLine()
+            ->comment('Start typing to filter by a test name.')
+            ->prompt('pattern > ');
+
+        return $this;
+    }
+
+    public function registerListeners()
+    {
+        $this->terminal->on('data', function ($line) {
+            if ($line == '') {
+                $this->terminal->goBack();
+
+                return;
+            }
+
+            $phpunitArguments = "--group={$line}";
+
+            $phpunitScreen = $this->terminal->getPreviousScreen();
+
+            $options = $phpunitScreen->options;
+
+            $options['phpunit']['arguments'] = $phpunitArguments;
+
+            $this->terminal->displayScreen(new Phpunit($options));
+        });
+
+        return $this;
+    }
+}

--- a/src/Screens/Phpunit.php
+++ b/src/Screens/Phpunit.php
@@ -42,6 +42,9 @@ class Phpunit extends Screen
 
                     $this->terminal->displayScreen(new Phpunit($this->options));
                     break;
+                case 'g':
+                    $this->terminal->displayScreen(new FilterGroupName());
+                    break;
                 case 't':
                     $this->terminal->displayScreen(new FilterTestName());
                     break;

--- a/src/Screens/Phpunit.php
+++ b/src/Screens/Phpunit.php
@@ -98,6 +98,7 @@ class Phpunit extends Screen
             ->write('<dim>Press </dim>a<dim> to run all tests.</dim>')
             ->write('<dim>Press </dim>t<dim> to filter by test name.</dim>')
             ->write('<dim>Press </dim>p<dim> to filter by file name.</dim>')
+            ->write('<dim>Press </dim>g<dim> to filter by group name.</dim>')
             ->write('<dim>Press </dim>q<dim> to quit the watcher.</dim>')
             ->write('<dim>Press </dim>Enter<dim> to trigger a test run.</dim>');
 


### PR DESCRIPTION
Similar to the suggestion in https://github.com/spatie/phpunit-watcher/issues/16#issuecomment-319874491 this PR seeks to add a new _interactive mode_ to allow filtering by [PHPUnit groups](https://phpunit.readthedocs.io/en/latest/textui.html?highlight=groups), e.g `phpunit --group=foo`

This PR is based on the original _interactive mode_ introduced in #11 