### PR TITLE
Add autocomplete in filter by filename screen

### DIFF
--- a/src/Screens/FilterFileName.php
+++ b/src/Screens/FilterFileName.php
@@ -45,11 +45,12 @@ class FilterFileName extends Screen
             $paths = glob("$word*", GLOB_MARK);
 
             if (empty($paths)) {
-                return [];
+                return;
             }
 
             if (count($paths) > 1) {
-                return $paths;
+                $this->terminal->getStdio()->write(implode('  ', $paths) . "\n");
+                return;
             }
 
             $path = $paths[0];

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -34,7 +34,7 @@ class Terminal
     public function onKeyPress(callable $callable)
     {
         $this->io->getInput()->once('data', function ($line) use ($callable) {
-            $this->io->getReadline()->deleteChar(0);
+            $this->getReadline()->deleteChar(0);
             $callable(trim($line));
         });
 
@@ -139,15 +139,20 @@ class Terminal
 
     public function prompt(string $prompt)
     {
-        $this->io->getReadline()->setPrompt($prompt);
+        $this->getReadline()->setPrompt($prompt);
 
         return $this;
     }
 
     public function clearPrompt()
     {
-        $this->io->getReadline()->setPrompt('');
+        $this->getReadline()->setPrompt('');
 
         return $this;
+    }
+
+    public function getReadline()
+    {
+        return $this->io->getReadline();
     }
 }

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -155,4 +155,9 @@ class Terminal
     {
         return $this->io->getReadline();
     }
+
+    public function getStdio()
+    {
+        return $this->io;
+    }
 }


### PR DESCRIPTION
Hi !

This PR add autocompletion in 'filter by filename' screen.

I tried to reproduce the behavior of bash for autocompletion.

- You can autocomplete anywhere in input.
- Quotes are supported.
- You can search for files using globbing. (it uses PHP [glob](http://php.net/manual/fr/function.glob.php) function)

⚠️ Even if you send multiple filenames, only one will be used by PHPUnit. So you can't use globbing for that.

This feature was also requested here #35.

Happy testing ! 😄 
