### PR TITLE
Allow a custom path for PHPUnit binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ notifications:
   passingTests: false
   failingTests: false
 phpunit:
+  binaryPath: vendor/bin/phpunit
   arguments: '--stop-on-failure'
 ```
 
@@ -110,7 +111,20 @@ notifications:
   failingTests: false
 ```
 
-### Initial PHPUnit arguments
+### Customize PHPUnit
+
+#### Binary
+
+By default the tool use `vendor/bin/phpunit` as default PHPUnit binary file, however, it may be useful to be able to customize this value for people who have a binary file in a different location. 
+
+You can specificy it in the `.phpunit-watcher.yml` config file. Here's an example:
+
+```yaml
+phpunit:
+  binaryPath: ./vendor/phpunit/phpunit/phpunit
+```
+
+#### Initial arguments
 
 If you want to use pass the same arguments to PHPUnit everytime to watcher starts, you can specificy those in the `.phpunit-watcher.yml` config file. Here's an example:
 

--- a/src/Screens/Phpunit.php
+++ b/src/Screens/Phpunit.php
@@ -7,17 +7,24 @@ use Spatie\PhpUnitWatcher\Notification;
 
 class Phpunit extends Screen
 {
+    const DEFAULT_BINARY_PATH = 'vendor/bin/phpunit';
+
     /** @var array */
     public $options;
 
     /** @var string */
     protected $phpunitArguments;
 
+    /** @var string */
+    private $phpunitBinaryPath;
+
     public function __construct(array $options)
     {
         $this->options = $options;
 
         $this->phpunitArguments = $options['phpunit']['arguments'] ?? '';
+
+        $this->phpunitBinaryPath = $options['phpunit']['binaryPath'] ?? self::DEFAULT_BINARY_PATH;
     }
 
     public function draw()
@@ -83,7 +90,7 @@ class Phpunit extends Screen
 
     protected function runTests()
     {
-        $result = (new Process("vendor/bin/phpunit {$this->phpunitArguments}"))
+        $result = (new Process("{$this->phpunitBinaryPath} {$this->phpunitArguments}"))
             ->setTty(true)
             ->run(function ($type, $line) {
                 echo $line;


### PR DESCRIPTION
Allow to customize PHPUnit binary path for people who have a binary file in a different location.

Example of `composer.json` file:

```
"config": {
  "bin-dir": "bin"
}
```

### Related issues & PR
- Ability to change binary and config locations/files #66 (open)
- Fail to detect the phpunit path if composer `bin-dir` config is used #61 (closed)
- Allow a custom path for composer binaries dir #52 (closed)

### Documentation
- Composer [Vendor binaries and the vendor/bin directory](https://getcomposer.org/doc/articles/vendor-binaries.md#vendor-binaries-and-the-vendor-bin-directory)