### PR TITLE
Add other config filename options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ phpunit-watcher watch --filter=it_can_run_a_single_test
 
 ## Customization
 
-Certain aspects of the behaviour of the tool can be modified. All options can be set in a `.phpunit-watcher.yml` in your project directory.
+Certain aspects of the behaviour of the tool can be modified. The file for options may be named `.phpunit-watcher.yml`, `phpunit-watcher.yml` or `phpunit-watcher.yml.dist`. The tool will look for a file in that order.
 
-If a such a config file does not exist in the project directory, the tool will check if the file exists in any of the parent directories of the project directory.
+If a config file does not exist in the project directory, the tool will check if a file exists in any of the parent directories of the project directory.
 
 Here's some example content. Read on for a more detailed explanation of all the options.
 

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -64,15 +64,21 @@ class WatcherCommand extends Command
 
     protected function getConfigFileLocation()
     {
-        $configName = '.phpunit-watcher.yml';
+        $configNames = [
+            '.phpunit-watcher.yml',
+            'phpunit-watcher.yml',
+            'phpunit-watcher.yml.dist',
+        ];
 
         $configDirectory = getcwd();
 
         while (is_dir($configDirectory)) {
-            $configFullPath = "{$configDirectory}/{$configName}";
+            foreach ($configNames as $configName) {
+                $configFullPath = "{$configDirectory}/{$configName}";
 
-            if (file_exists($configFullPath)) {
-                return $configFullPath;
+                if (file_exists($configFullPath)) {
+                    return $configFullPath;
+                }
             }
 
             if ($configDirectory === DIRECTORY_SEPARATOR) {


### PR DESCRIPTION
We would like to use a different filename variation for our config, one that is inline with other open source projects so the format is similar. 

To achieve that I added some variations on the filename and documented how to use the variations. I mimicked the order to be similar to other projects, though some have way more variations than I think is useful.

Was not sure how to write tests around this as there are few to base them on but I'll add them if I'm given some inspiration.

References:
- [PHPUnit config filenames](https://phpunit.readthedocs.io/en/7.3/textui.html#textui-clioptions) (under the `--configuration` option)
- [PHPCS config filenames](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file)
- [PHPStan config filenames](https://github.com/phpstan/phpstan/blob/master/README.md#configuration)
- [The `.dist` extension origin](https://stackoverflow.com/questions/16843080/what-does-dist-used-as-an-extension-of-some-source-code-file-mean)