### PR TITLE
Update to version 2 of react-stdio and use new methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "clue/stdio-react": "^1.0",
+        "clue/stdio-react": "^2.0",
         "jolicode/jolinotif": "^2.0",
         "symfony/console": "^3.0|^4.0",
         "symfony/process": "^3.0|^4.0",

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -33,7 +33,7 @@ class Terminal
 
     public function onKeyPress(callable $callable)
     {
-        $this->io->getInput()->once('data', function ($line) use ($callable) {
+        $this->io->once('data', function ($line) use ($callable) {
             $this->getReadline()->deleteChar(0);
             $callable(trim($line));
         });
@@ -66,7 +66,7 @@ class Terminal
         $formattedMessage = str_replace('<dim>', "\e[2m", $formattedMessage);
         $formattedMessage = str_replace('</dim>', "\e[22m", $formattedMessage);
 
-        $this->io->writeln($formattedMessage);
+        $this->io->write($formattedMessage.PHP_EOL);
 
         return $this;
     }


### PR DESCRIPTION
Related to this issue https://github.com/spatie/phpunit-watcher/issues/60
I found on the react-stdio project that this was reported and fixed on version 2.2 https://github.com/clue/reactphp-stdio/issues/66 
The project was locked up to version 1.0 so I updated and just have to update 2 methods to make this work. 