### PR TITLE
Add option to hide helper messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ notifications:
   failingTests: false
 ```
 
+### Help messages
+By default the tool will display a helper for keyboard actions after each run. You can hide these help messages by adding a `hideManual` key in the `.phpunit-watcher.yml`.
+
+```yaml
+hideManual: true
+```
+
 ### Customize PHPUnit
 
 #### Binary

--- a/src/Screens/Phpunit.php
+++ b/src/Screens/Phpunit.php
@@ -103,6 +103,10 @@ class Phpunit extends Screen
 
     protected function displayManual()
     {
+        if ($this->options['hideManual']) {
+            return $this;
+        }
+
         $this->terminal
             ->emptyLine()
             ->write('<dim>Press </dim>a<dim> to run all tests.</dim>')

--- a/src/WatcherFactory.php
+++ b/src/WatcherFactory.php
@@ -46,6 +46,7 @@ class WatcherFactory
                 'passingTests' => true,
                 'failingTests' => true,
             ],
+            'hideManual' => false
         ], $options);
 
         $options['watch']['directories'] = array_map(function ($directory) {

--- a/src/WatcherFactory.php
+++ b/src/WatcherFactory.php
@@ -46,7 +46,7 @@ class WatcherFactory
                 'passingTests' => true,
                 'failingTests' => true,
             ],
-            'hideManual' => false
+            'hideManual' => false,
         ], $options);
 
         $options['watch']['directories'] = array_map(function ($directory) {


### PR DESCRIPTION
This pull request adds an option to hide helper messages, which display after the tests finished, as requested in https://github.com/spatie/phpunit-watcher/issues/83

A new option, "hideManual" has been introduced, with a default false value. 
If this option is set to true in the yml, the helper messages will not show.