### PR TITLE
Autofilter: Mode for only running tests relevant to changed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Want to pass some arguments to PHPUnit? No problem, just tack them on:
 phpunit-watcher watch --filter=it_can_run_a_single_test
 ```
 
+### Auto-filter mode
+This package has a secondary mode that automatically runs only the tests related to changed files:
+
+```bash
+phpunit-watcher --auto-filter watch
+```
+
+In this mode, making a change to SomeClass.php will run the tests in `SomeClassTest`. It also works when editing tests.
+
+Note: The `--auto-filter` (or `-a`) option must come **before** the `watch` command, or else it will be passed to PHPUnit.
+
 ## Customization
 
 Certain aspects of the behaviour of the tool can be modified. The file for options may be named `.phpunit-watcher.yml`, `phpunit-watcher.yml` or `phpunit-watcher.yml.dist`. The tool will look for a file in that order.
@@ -122,7 +133,7 @@ hideManual: true
 
 #### Binary
 
-By default the tool use `vendor/bin/phpunit` as default PHPUnit binary file, however, it may be useful to be able to customize this value for people who have a binary file in a different location. 
+By default the tool use `vendor/bin/phpunit` as default PHPUnit binary file, however, it may be useful to be able to customize this value for people who have a binary file in a different location.
 
 You can specificy it in the `.phpunit-watcher.yml` config file. Here's an example:
 
@@ -181,7 +192,7 @@ Interactive commands were inspired by [Jest](https://facebook.github.io/jest/).
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -71,7 +71,7 @@ class Terminal
         return $this;
     }
 
-    public function displayScreen(Screen $screen, $clearScreen = true)
+    public function displayScreen(Screen $screen, $clearScreen = true, array $changedFilePaths = [])
     {
         $this->previousScreen = $this->currentScreen;
 
@@ -87,7 +87,7 @@ class Terminal
             $screen->clear();
         }
 
-        $screen->draw();
+        $screen->draw($changedFilePaths);
 
         return $this;
     }
@@ -110,13 +110,13 @@ class Terminal
         return $this->previousScreen;
     }
 
-    public function refreshScreen()
+    public function refreshScreen(array $changedFilePaths = [])
     {
         if (is_null($this->currentScreen)) {
             return;
         }
 
-        $this->displayScreen($this->currentScreen);
+        $this->displayScreen($this->currentScreen, true, $changedFilePaths);
 
         return $this;
     }

--- a/src/Watcher.php
+++ b/src/Watcher.php
@@ -50,7 +50,16 @@ class Watcher
             $watcher->findChanges();
 
             if ($watcher->hasChanges()) {
-                $this->terminal->refreshScreen();
+                $changedFilePaths = [];
+
+                if ($this->options['autoFilter']) {
+                    $changedFilePaths = array_merge(
+                        $watcher->getUpdatedResources(),
+                        $watcher->getDeletedResources(),
+                        $watcher->getNewResources());
+                }
+
+                $this->terminal->refreshScreen($changedFilePaths);
             }
         });
 

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -4,6 +4,7 @@ namespace Spatie\PhpUnitWatcher;
 
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -16,6 +17,11 @@ class WatcherCommand extends Command
     {
         $this->setName('watch')
             ->setDescription('Rerun PHPUnit tests when source code changes.')
+            ->addOption(
+                'auto-filter',
+                'a',
+                InputOption::VALUE_NONE,
+                'Only run tests corresponding to edited files.')
             ->addArgument('phpunit-options', InputArgument::OPTIONAL, 'Options passed to phpunit');
     }
 
@@ -33,6 +39,8 @@ class WatcherCommand extends Command
     protected function determineOptions(InputInterface $input): array
     {
         $options = $this->getOptionsFromConfigFile();
+
+        $options['autoFilter'] = $input->getOption('auto-filter');
 
         $commandLineArguments = trim($input->getArgument('phpunit-options'), "'");
 
@@ -102,12 +110,17 @@ class WatcherCommand extends Command
         } else {
             $output->text('No config file detected. Using default options.');
         }
-        $output->newLine();
 
         $output->text("Tests will be rerun when {$options['watch']['fileMask']} files are modified in");
 
         $output->listing($options['watch']['directories']);
 
         $output->newLine();
+
+        if ($options['autoFilter']) {
+            $output->text('Tests will be filtered corresponding to the changed filename.');
+            $output->text('For example, editing BlogService.php will filter for BlogServiceTest.');
+            $output->newLine();
+        }
     }
 }

--- a/tests/Screens/PhpunitTest.php
+++ b/tests/Screens/PhpunitTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Spatie\PhpUnitWatcher\Test\Screens;
+
+use Clue\React\Stdio\Stdio;
+use PHPUnit\Framework\TestCase;
+use Spatie\PhpUnitWatcher\Terminal;
+use Spatie\PhpUnitWatcher\Screens\Phpunit;
+use React\EventLoop\Factory as LoopFactory;
+
+class PhpunitTest extends TestCase
+{
+    protected $terminal;
+    protected $screen;
+
+    public function setUp()
+    {
+        $this->terminal = new Terminal(new Stdio(LoopFactory::create()));
+        $this->screen = (new Phpunit(['autoFilter' => true]))
+            ->useTerminal($this->terminal);
+    }
+
+    public function tearDown()
+    {
+        unset($this->screen, $this->terminal);
+    }
+
+    /** @test */
+    public function phpunit_determine_autofilter_works_single_file()
+    {
+        // After draw, $screen::phpunitArguments should include filter for FakeFileTest
+        $this->screen->determineAutoFilter(['/this/is/a/test/path/to/a/FakeFile.php']);
+        $this->assertObjectHasAttribute('phpunitArguments', $this->screen);
+
+        // Make sure phpunitArguments filters on FakeFileTest
+        $this->assertContains(
+            '--filter="/(FakeFileTest)/"',
+            $this->screen->getPhpunitArguments(),
+            'Expected filter was not set');
+    }
+
+    /** @test */
+    public function phpunit_determine_autofilter_works_multiple_files()
+    {
+        // After draw, $screen::phpunitArguments should include filter for FakeFileTest
+        $this->screen->determineAutoFilter([
+            '/this/is/a/test/path/to/a/FakeFile1.php',
+            '/test/path/to/a/FakeFile2.php',
+        ]);
+        $this->assertObjectHasAttribute('phpunitArguments', $this->screen);
+
+        // Make sure phpunitArguments filters on FakeFileTest
+        $this->assertContains(
+            '--filter="/(FakeFile1Test|FakeFile2Test)/"',
+            $this->screen->getPhpunitArguments(),
+            'Expected filter was not set');
+    }
+}


### PR DESCRIPTION
Implements Issue #64.

This allows users to run the watcher in a new mode called "auto-filter" by passing the --auto-filter option in when running the watch command:

```bash
phpunit-watcher --auto-filter watch
```

I'm this mode, phpunit-watcher will infer test names from the names of modified, deleted and new files. Then it will run PHPUnit with a filter for those inferred names.

For example, if the user edits BlogService.php, this mode will then run PHPUnit with --filter=BlogServiceTest. I chose this convention of determining test names because it's the most common one I've seen (naming php files after the class they contain, and naming test classes as the class they test suffixed with "Test"). I'm open to a more configurable method if there is a need.

Auto-filter mode replaces the default functionality of allowing users to key input to run all or filtered tests.