### PR TITLE
Update output version number

### DIFF
--- a/src/ConsoleApplication.php
+++ b/src/ConsoleApplication.php
@@ -8,7 +8,7 @@ class ConsoleApplication extends Application
 {
     public function __construct()
     {
-        parent::__construct('PHPUnit Watcher', '1.5.0');
+        parent::__construct('PHPUnit Watcher', '1.11.1');
 
         $this->add(new WatcherCommand());
     }


### PR DESCRIPTION
The version number is output when you run `phpunit-watch` and also when you specifically run `phpunit-watcher -v`

I've upped the last number in anticipation for a patch release 😄 