### PR TITLE
Remove deleteChar call, cause it's private

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -34,7 +34,6 @@ class Terminal
     public function onKeyPress(callable $callable)
     {
         $this->io->once('data', function ($line) use ($callable) {
-            $this->getReadline()->deleteChar(0);
             $callable(trim($line));
         });
 


### PR DESCRIPTION
https://github.com/spatie/phpunit-watcher/pull/80 updated the dependency `clue/stdio-react` to version 2. This version has made the method `deleteChar` `private`. Hence, no filter could be executed. PHP throws an Error because of private method access.

The library does not provide another method to backspace (there is a `onBackspace` method, but it is marked `@internal`, so I did not want to use it either)

This PR fixes phpunit-watcher filters.