### PR TITLE
Add RandomSeed Screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `phpunit-watcher` will be documented in this file
 
+## Unreleased
+
+- new random seed feature. Run tests in random order.
+
 ## 1.11.2 - 2019-09-09
 
 - Remove `deleteChar` call

--- a/src/Screens/Phpunit.php
+++ b/src/Screens/Phpunit.php
@@ -61,6 +61,9 @@ class Phpunit extends Screen
                 case 'p':
                     $this->terminal->displayScreen(new FilterFileName());
                     break;
+                case 'r':
+                    $this->terminal->displayScreen(new RandomSeed());
+                    break;
                 case 'q':
                     die();
                     break;
@@ -114,6 +117,7 @@ class Phpunit extends Screen
             ->write('<dim>Press </dim>p<dim> to filter by file name.</dim>')
             ->write('<dim>Press </dim>g<dim> to filter by group name.</dim>')
             ->write('<dim>Press </dim>s<dim> to filter by test suite name.</dim>')
+            ->write('<dim>Press </dim>r<dim> to run tests with a random seed.</dim>')
             ->write('<dim>Press </dim>q<dim> to quit the watcher.</dim>')
             ->write('<dim>Press </dim>Enter<dim> to trigger a test run.</dim>');
 

--- a/src/Screens/RandomSeed.php
+++ b/src/Screens/RandomSeed.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Spatie\PhpUnitWatcher\Screens;
+
+class RandomSeed extends Screen
+{
+    public function draw()
+    {
+        $this->terminal
+            ->comment('Random seed usage')
+            ->write('Type a seed and press Enter to run tests in random order but with a specific seed.')
+            ->write('Press Enter with an empty pattern to execute all tests in random order.')
+            ->emptyLine()
+            ->comment('Start typing to add a random seed')
+            ->prompt('seed > ');
+
+        return $this;
+    }
+
+    public function registerListeners()
+    {
+        $this->terminal->on('data', function ($line) {
+            $phpunitArguments = '--order-by=random';
+            if ($line !== '') {
+                $phpunitArguments .= " --random-order-seed={$line}";
+            }
+
+            $phpunitScreen = $this->terminal->getPreviousScreen();
+
+            $options = $phpunitScreen->options;
+
+            $options['phpunit']['arguments'] = $phpunitArguments;
+
+            $this->terminal->displayScreen(new Phpunit($options));
+        });
+
+        return $this;
+    }
+}


### PR DESCRIPTION
New feature to run phpunit-watcher with a random seed.

The letter `r` activates the random seed feature. Add a seed an `phpunit-watch` runs all tests with that seed.