### PR TITLE
Increase version number

### DIFF
--- a/src/ConsoleApplication.php
+++ b/src/ConsoleApplication.php
@@ -8,7 +8,7 @@ class ConsoleApplication extends Application
 {
     public function __construct()
     {
-        parent::__construct('PHPUnit Watcher', '1.11.1');
+        parent::__construct('PHPUnit Watcher', '1.12.1');
 
         $this->add(new WatcherCommand());
     }


### PR DESCRIPTION
Updated version number to correctly reflect the current release. Version number is output when you run `phpunit-watch` or run `phpunit-watcher -v`

I've upped the last number in anticipation for a patch release 😄