### PR TITLE
Fix windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Want to pass some arguments to PHPUnit? No problem, just tack them on:
 phpunit-watcher watch --filter=it_can_run_a_single_test
 ```
 
+#### A note for Windows users
+Currently, TTY is not being supported, so any interaction has been disabled. While watching for changes works,
+any arguments for PHPUnit have to be provided when initially calling `phpunit-watcher`.
+
 ## Customization
 
 Certain aspects of the behaviour of the tool can be modified. The file for options may be named `.phpunit-watcher.yml`, `phpunit-watcher.yml` or `phpunit-watcher.yml.dist`. The tool will look for a file in that order.

--- a/src/OS.php
+++ b/src/OS.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\PhpUnitWatcher;
+
+class OS
+{
+    /**
+     * Indicates if the process is being executed in a windows machine.
+     *
+     * @return bool
+     */
+    public static function isOnWindows()
+    {
+        return DIRECTORY_SEPARATOR !== '/';
+    }
+}

--- a/src/Screens/Phpunit.php
+++ b/src/Screens/Phpunit.php
@@ -94,7 +94,7 @@ class Phpunit extends Screen
     protected function runTests()
     {
         $result = (new Process(array_merge([$this->phpunitBinaryPath], explode(' ', $this->phpunitArguments))))
-            ->setTty(true)
+            ->setTty(Process::isTtySupported())
             ->run(function ($type, $line) {
                 echo $line;
             });

--- a/src/Watcher.php
+++ b/src/Watcher.php
@@ -62,7 +62,7 @@ class Watcher
     {
         $output = null;
 
-        if (DIRECTORY_SEPARATOR !== '/') {
+        if (OS::isOnWindows()) {
             // Interaction on windows is currently not supported
             fclose(STDIN);
 

--- a/src/Watcher.php
+++ b/src/Watcher.php
@@ -4,6 +4,7 @@ namespace Spatie\PhpUnitWatcher;
 
 use Clue\React\Stdio\Stdio;
 use React\EventLoop\Factory;
+use React\Stream\ThroughStream;
 use Symfony\Component\Finder\Finder;
 use Spatie\PhpUnitWatcher\Screens\Phpunit;
 use Yosymfony\ResourceWatcher\ResourceWatcher;
@@ -29,7 +30,7 @@ class Watcher
 
         $this->loop = Factory::create();
 
-        $this->terminal = new Terminal(new Stdio($this->loop));
+        $this->terminal = new Terminal($this->buildStdio());
 
         $this->options = $options;
     }
@@ -55,5 +56,23 @@ class Watcher
         });
 
         $this->loop->run();
+    }
+
+    protected function buildStdio()
+    {
+        $output = null;
+
+        if (DIRECTORY_SEPARATOR !== '/') {
+            // Interaction on windows is currently not supported
+            fclose(STDIN);
+
+            // Simple fix for windows comparability since we don't write a lot of data at once
+            // https://github.com/clue/reactphp-stdio/issues/83#issuecomment-546678609
+            $output = new ThroughStream(static function ($data) {
+                echo $data;
+            });
+        }
+
+        return new Stdio($this->loop, null, $output);
     }
 }

--- a/src/Watcher.php
+++ b/src/Watcher.php
@@ -66,7 +66,7 @@ class Watcher
             // Interaction on windows is currently not supported
             fclose(STDIN);
 
-            // Simple fix for windows comparability since we don't write a lot of data at once
+            // Simple fix for windows compatibility since we don't write a lot of data at once
             // https://github.com/clue/reactphp-stdio/issues/83#issuecomment-546678609
             $output = new ThroughStream(static function ($data) {
                 echo $data;

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -74,17 +74,23 @@ class WatcherCommand extends Command
 
         while (is_dir($configDirectory)) {
             foreach ($configNames as $configName) {
-                $configFullPath = "{$configDirectory}/{$configName}";
+                $configFullPath = $configDirectory.DIRECTORY_SEPARATOR.$configName;
 
                 if (file_exists($configFullPath)) {
                     return $configFullPath;
                 }
             }
 
-            if ($configDirectory === DIRECTORY_SEPARATOR) {
+            $parentDirectory = dirname($configDirectory);
+
+            // We do a direct comparison here since there's a difference between
+            // the root directories on windows / *nix systems which does not
+            // let us compare it against the DIRECTORY_SEPARATOR directly
+            if ($parentDirectory === $configDirectory) {
                 return;
             }
-            $configDirectory = dirname($configDirectory);
+
+            $configDirectory = $parentDirectory;
         }
     }
 

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -40,7 +40,7 @@ class WatcherCommand extends Command
             $options['phpunit']['arguments'] = $commandLineArguments;
         }
 
-        if (DIRECTORY_SEPARATOR === '\\') {
+        if (OS::isOnWindows()) {
             $options['hideManual'] = true;
         }
 

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -40,6 +40,10 @@ class WatcherCommand extends Command
             $options['phpunit']['arguments'] = $commandLineArguments;
         }
 
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $options['hideManual'] = true;
+        }
+
         return $options;
     }
 

--- a/tests/PhpunitWatcherTest.php
+++ b/tests/PhpunitWatcherTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\PhpUnitWatcher\Test;
 
+use Spatie\PhpUnitWatcher\OS;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
@@ -10,7 +11,7 @@ class PhpunitWatcherTest extends TestCase
     /** @test */
     public function the_watcher_can_be_executed()
     {
-        $process = new Process(DIRECTORY_SEPARATOR === '\\' ? 'php phpunit-watcher' : './phpunit-watcher');
+        $process = new Process(OS::isOnWindows() ? ['php', 'phpunit-watcher'] : ['./phpunit-watcher']);
 
         $process->run();
 

--- a/tests/PhpunitWatcherTest.php
+++ b/tests/PhpunitWatcherTest.php
@@ -10,7 +10,7 @@ class PhpunitWatcherTest extends TestCase
     /** @test */
     public function the_watcher_can_be_executed()
     {
-        $process = new Process('./phpunit-watcher');
+        $process = new Process(DIRECTORY_SEPARATOR === '\\' ? 'php phpunit-watcher' : './phpunit-watcher');
 
         $process->run();
 


### PR DESCRIPTION
This is a first start to fix (the already closed) #48.

While TTY is still not supported, the command can at least be executed on a windows computer. Any commands inside the screens have been disabled, but the watching and re-running of tests works as expected.

I was debating whether I should create an extra class like "OS" that has a single `isOnWindows` method, instead of inlining the checks all the time. If that's something you'd like to see I can still do that change.