### PR TITLE
WatcherFactory: Merge options recursively to preserve nested values.

### DIFF
--- a/src/WatcherFactory.php
+++ b/src/WatcherFactory.php
@@ -30,10 +30,9 @@ class WatcherFactory
         return [$watcher, $options];
     }
 
-    protected static function mergeWithDefaultOptions(array $options): array
+    public static function getDefaultOptions(): array
     {
-        $options = array_merge([
-
+        return [
             'watch' => [
                 'directories' => [
                     'app',
@@ -47,7 +46,12 @@ class WatcherFactory
                 'failingTests' => true,
             ],
             'hideManual' => false,
-        ], $options);
+        ];
+    }
+
+    protected static function mergeWithDefaultOptions(array $options): array
+    {
+        $options = array_replace_recursive(self::getDefaultOptions(), $options);
 
         $options['watch']['directories'] = array_map(function ($directory) {
             return getcwd()."/{$directory}";

--- a/src/WatcherFactory.php
+++ b/src/WatcherFactory.php
@@ -49,18 +49,26 @@ class WatcherFactory
         ];
     }
 
-    protected static function mergeWithDefaultOptions(array $options): array
+    protected static function mergeWithDefaultOptions(array $userOptions): array
     {
-        $options = array_replace_recursive(self::getDefaultOptions(), $options);
+        // Merge all options with the defaults, so that there's always a complete set.
+        $mergedOptions = array_replace_recursive(self::getDefaultOptions(), $userOptions);
 
-        $options['watch']['directories'] = array_map(function ($directory) {
+        // Exception to above: Allow directories to be overwritten entirely, because that's usually desired.
+        if (isset($userOptions['watch']['directories'])) {
+            $mergedOptions['watch']['directories'] = $userOptions['watch']['directories'];
+        }
+
+        $mergedOptions['watch']['directories'] = array_unique($mergedOptions['watch']['directories']);
+
+        $mergedOptions['watch']['directories'] = array_map(function ($directory) {
             return getcwd()."/{$directory}";
-        }, $options['watch']['directories']);
+        }, $mergedOptions['watch']['directories']);
 
-        $options['watch']['directories'] = array_filter($options['watch']['directories'], function ($directory) {
+        $mergedOptions['watch']['directories'] = array_filter($mergedOptions['watch']['directories'], function ($directory) {
             return file_exists($directory);
         });
 
-        return $options;
+        return $mergedOptions;
     }
 }

--- a/tests/WatcherFactoryTest.php
+++ b/tests/WatcherFactoryTest.php
@@ -7,19 +7,7 @@ use Spatie\PhpUnitWatcher\WatcherFactory;
 
 class WatcherFactorTest extends TestCase
 {
-	public function setUp() {
-		parent::setUp();
-
-		// todo need to create foo and bar folders inside current working dir
-	}
-
-	public function tearDown() {
-		parent::tearDown();
-
-		// todo revert setUp();
-	}
-
-	/** @test */
+    /** @test */
     public function it_can_be_instantiated()
     {
         $factory = new WatcherFactory();
@@ -27,35 +15,36 @@ class WatcherFactorTest extends TestCase
         $this->assertInstanceOf(WatcherFactory::class, $factory);
     }
 
-    /**
-     * @test
-     *
-     * @covers WatcherFactory::create
-     *
-     * @dataProvider data_options_are_replaced_recursively
-     */
-	public function options_are_replaced_recursively( $userOptions, $expectedOptions ) {
-		$watcher = WatcherFactory::create( $userOptions );
-		$actualOptions = $watcher[1];
+    /** @test */
+    public function setting_notification_preserves_other_options()
+    {
+        $userOptions = [
+            'notifications' => [
+                'passingTests' => false,
+            ],
+        ];
 
-		$this->assertEquals( $expectedOptions, $actualOptions );
-	}
+        $actualOptions = WatcherFactory::create($userOptions)[1];
 
-	public function data_options_are_replaced_recursively() {
-		$cases = array();
-		$defaults = WatcherFactory::getDefaultOptions();
+        $this->assertFalse($actualOptions['notifications']['passingTests']);
+        $this->assertTrue($actualOptions['notifications']['failingTests']);
+        $this->assertFalse($actualOptions['hideManual']);
+        $this->assertSame('*.php', $actualOptions['watch']['fileMask']);
+    }
 
-		// Setting watch.directories should leave all other defaults in tact.
-		$cases['overwriteDirectoriesButNotMask'] = array(
-    	    array(
-    	    	'watch' => array(
-	                'directories' => array( 'foo', 'bar' )
-		        ),
-            ),
-			$defaults
-		);
-    	$cases['overwriteDirectoriesButNotMask'][1]['watch']['directories'] = array( 'foo', 'bar' );
+    /** @test */
+    public function setting_directories_preserves_other_options()
+    {
+        $userOptions = [
+            'watch' => [
+                'directories' => ['foo', 'bar'],
+            ],
+        ];
 
-    	return $cases;
-	}
+        $actualOptions = WatcherFactory::create($userOptions)[1];
+
+        $this->assertTrue($actualOptions['notifications']['failingTests']);
+        $this->assertFalse($actualOptions['hideManual']);
+        $this->assertSame('*.php', $actualOptions['watch']['fileMask']);
+    }
 }

--- a/tests/WatcherFactoryTest.php
+++ b/tests/WatcherFactoryTest.php
@@ -37,7 +37,7 @@ class WatcherFactorTest extends TestCase
     {
         $userOptions = [
             'watch' => [
-                'directories' => ['foo', 'bar'],
+                'directories' => ['lib', 'tests'],
             ],
         ];
 

--- a/tests/WatcherFactoryTest.php
+++ b/tests/WatcherFactoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Spatie\PhpUnitWatcher\Test;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\PhpUnitWatcher\WatcherFactory;
+
+class WatcherFactorTest extends TestCase
+{
+	public function setUp() {
+		parent::setUp();
+
+		// todo need to create foo and bar folders inside current working dir
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		// todo revert setUp();
+	}
+
+	/** @test */
+    public function it_can_be_instantiated()
+    {
+        $factory = new WatcherFactory();
+
+        $this->assertInstanceOf(WatcherFactory::class, $factory);
+    }
+
+    /**
+     * @test
+     *
+     * @covers WatcherFactory::create
+     *
+     * @dataProvider data_options_are_replaced_recursively
+     */
+	public function options_are_replaced_recursively( $userOptions, $expectedOptions ) {
+		$watcher = WatcherFactory::create( $userOptions );
+		$actualOptions = $watcher[1];
+
+		$this->assertEquals( $expectedOptions, $actualOptions );
+	}
+
+	public function data_options_are_replaced_recursively() {
+		$cases = array();
+		$defaults = WatcherFactory::getDefaultOptions();
+
+		// Setting watch.directories should leave all other defaults in tact.
+		$cases['overwriteDirectoriesButNotMask'] = array(
+    	    array(
+    	    	'watch' => array(
+	                'directories' => array( 'foo', 'bar' )
+		        ),
+            ),
+			$defaults
+		);
+    	$cases['overwriteDirectoriesButNotMask'][1]['watch']['directories'] = array( 'foo', 'bar' );
+
+    	return $cases;
+	}
+}


### PR DESCRIPTION
Previously, the following configuration would result in a file mask of `null`, because the entire `watch` item would be overridden.

```yml
watch:
  directories:
    - ./public_html/wp-content/mu-plugins/
    - ./public_html/wp-content/plugins/camptix/
    - ./public_html/wp-content/plugins/wordcamp-organizer-reminders/
    - ./public_html/wp-content/plugins/wordcamp-remote-css/
    - ./public_html/wp-content/plugins/wordcamp-speaker-feedback/

notifications:
  passingTests: false
  failingTests: false
```

Now users can selective set a nested option like `watch.fileMask`, without having to set everything inside `watch`.