### PR TITLE
WatcherFactory: Add support for `exclude` and `ignore` options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,17 @@ watch:
   directories:
     - src
     - tests
+  exclude:
+    - lib
   fileMask: '*.php'
+  ignoreDotFiles: true
+  ignoreVCS: true
+  ignoreVCSIgnored: false
 ```
+
+See [the documentation for Finder](https://symfony.com/doc/current/components/finder.html) for more details.
+
+If you experience performance delays with large repositories, try adding `exclude` entries for any large subdirectories that you don't need to watch. Enabling the `ignore...` options can also be helpful. It's also important to ensure you're also using the `'*.php'` file mask.
 
 ### Desktop notifications
 

--- a/src/WatcherFactory.php
+++ b/src/WatcherFactory.php
@@ -19,10 +19,12 @@ class WatcherFactory
         }
 
         $finder = (new Finder())
-            ->ignoreDotFiles(false)
-            ->ignoreVCS(false)
+            ->ignoreDotFiles($options['watch']['ignoreDotFiles'])
+            ->ignoreVCS($options['watch']['ignoreVCS'])
+            ->ignoreVCSIgnored($options['watch']['ignoreVCSIgnored'])
             ->name($options['watch']['fileMask'])
             ->files()
+            ->exclude($options['watch']['exclude'])
             ->in($options['watch']['directories']);
 
         $watcher = new Watcher($finder, $options);
@@ -40,6 +42,10 @@ class WatcherFactory
                     'src',
                     'tests',
                 ],
+                'exclude' => [],
+                'ignoreDotFiles' => false,
+                'ignoreVCS' => false,
+                'ignoreVCSIgnored' => false,
                 'fileMask' => '*.php',
             ],
             'notifications' => [


### PR DESCRIPTION
Fixes #113

I didn't see a good way to write tests for these, but they're each working in my manual tests.

You'll get an error if the following aren't set in the YML file, because of #115. This probably shouldn't be released until that is also merged.

> Fatal error: Uncaught TypeError: Argument 1 passed to Symfony\Component\Finder\Finder::ignoreVCS() must be of the type boolean, null given, called in src/WatcherFactory.php on line 23 and defined in vendor/symfony/finder/Finder.php on line 363