### PR TITLE
fix: replace passthru with echo

### DIFF
--- a/src/Screens/Screen.php
+++ b/src/Screens/Screen.php
@@ -28,7 +28,7 @@ abstract class Screen
 
     public function clear()
     {
-        passthru("echo '\033\143'");
+        echo("\033\143");
 
         return $this;
     }


### PR DESCRIPTION
`passthru` is disabled in most security oriented PHP setups since it allows shell access.

I replaced it with native PHP `echo` and locally my terminal gets cleared perfectly, what was the reason to do this with echo?