### PR TITLE
fix php-cs-fix-er workflow and up mim reqs to 8.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 7.4, 7.3, 7.2]
+        php: [8.1, 8.0, 7.4, 7.3, 7.2]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 composer.lock
 vendor
 .phpunit.result.cache
+.php-cs-fixer.cache

--- a/.php_cs.dist.php
+++ b/.php_cs.dist.php
@@ -10,14 +10,16 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return PhpCsFixer\Config::create()
+$config = new PhpCsFixer\Config;
+
+return $config
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => true,
         'phpdoc_scalar' => true,
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,
@@ -28,7 +30,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_var_without_name' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'method_argument_space' => [

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 | ^8.0",
+        "php": "^7.2 | ^8.0 | ^8.1",
         "clue/stdio-react": "^2.4",
         "jolicode/jolinotif": "^2.2",
         "symfony/console": "^5.2",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "clue/stdio-react": "^2.4",
         "jolicode/jolinotif": "^2.2",
         "symfony/console": "^5.2",
-        "symfony/finder": "^5.2",
-        "symfony/process": "^5.2",
+        "symfony/finder": "^5.4",
+        "symfony/process": "^6",
         "symfony/yaml": "^5.2",
         "yosymfony/resource-watcher": "^2.0"
     },
@@ -29,7 +29,7 @@
         "yosymfony/resource-watcher": "<2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0 | ^9.0"
+        "phpunit/phpunit": "^8.6 | ^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi, i fixed the php-cs-fixer workflow to be compatible with the new options.

symfony/process, symfony/finder and phpunit appears to have the php filter wrong, so i changed the minimum version of these packages to be able to run at PHP 8.1, I don't know if that is the right way to do it.