### PR TITLE
feat: allow symfony 5 or 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,15 @@
         "php": "^7.2 | ^8.0 | ^8.1",
         "clue/stdio-react": "^2.4",
         "jolicode/jolinotif": "^2.2",
-        "symfony/console": "^5.2",
-        "symfony/finder": "^5.4",
-        "symfony/process": "^6",
-        "symfony/yaml": "^5.2",
-        "yosymfony/resource-watcher": "^2.0"
+        "symfony/console": "^5 | ^6",
+        "symfony/finder": "^5.4 | ^6",
+        "symfony/process": "^5.4 | ^6",
+        "symfony/yaml": "^5.2 | ^6",
+        "yosymfony/resource-watcher": "^2.0 | ^3.0"
     },
     "conflict": {
-        "yosymfony/resource-watcher": "<2.0"
+        "yosymfony/resource-watcher": "<2.0",
+        "symfony/console": "<5.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.6 | ^9.0"


### PR DESCRIPTION
With the changes I submitted before it kind made the package incompatible with symfony 6 and 5 because of the mixed versions. I fixed it to able to install this with Symfony 5 or 6, or mixed of both.