### PR TITLE
#159 Update dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0]
+        php: [8.3, 8.2, 8.1, 8.0]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ build
 composer.lock
 vendor
 .phpunit.result.cache
+.phpunit.cache
 .php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/console": "<5.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "^8.6 | ^9.0 | ^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": "^7.2 | ^8.0 | ^8.1",
+        "php": "^7.2 | ^8.0",
         "clue/stdio-react": "^2.4",
         "jolicode/jolinotif": "^2.2",
-        "symfony/console": "^5 | ^6",
-        "symfony/finder": "^5.4 | ^6",
-        "symfony/process": "^5.4 | ^6",
-        "symfony/yaml": "^5.2 | ^6",
+        "symfony/console": "^5 | ^6 | ^7",
+        "symfony/finder": "^5.4 | ^6 | ^7",
+        "symfony/process": "^5.4 | ^6 | ^7",
+        "symfony/yaml": "^5.2 | ^6 | ^7",
         "yosymfony/resource-watcher": "^2.0 | ^3.0"
     },
     "conflict": {
@@ -30,7 +30,7 @@
         "symfony/console": "<5.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.6 | ^9.0"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="Spatie Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+    <coverage/>
+    <testsuites>
+        <testsuite name="Spatie Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/ConsoleApplication.php
+++ b/src/ConsoleApplication.php
@@ -13,7 +13,7 @@ class ConsoleApplication extends Application
         $this->add(new WatcherCommand());
     }
 
-    public function getLongVersion()
+    public function getLongVersion(): string
     {
         return parent::getLongVersion().' by <comment>Spatie</comment>';
     }

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -19,7 +19,7 @@ class WatcherCommand extends Command
             ->addArgument('phpunit-options', InputArgument::OPTIONAL, 'Options passed to phpunit');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $options = $this->determineOptions($input);
 
@@ -28,6 +28,8 @@ class WatcherCommand extends Command
         $this->displayOptions($options, $input, $output);
 
         $watcher->startWatching();
+
+        return 0;
     }
 
     protected function determineOptions(InputInterface $input): array

--- a/tests/PhpunitWatcherTest.php
+++ b/tests/PhpunitWatcherTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\Attributes\Test;
 
 class PhpunitWatcherTest extends TestCase
 {
-    /** @test */
     #[Test]
     public function the_watcher_can_be_executed()
     {

--- a/tests/PhpunitWatcherTest.php
+++ b/tests/PhpunitWatcherTest.php
@@ -5,10 +5,12 @@ namespace Spatie\PhpUnitWatcher\Test;
 use PHPUnit\Framework\TestCase;
 use Spatie\PhpUnitWatcher\OS;
 use Symfony\Component\Process\Process;
+use PHPUnit\Framework\Attributes\Test;
 
 class PhpunitWatcherTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function the_watcher_can_be_executed()
     {
         $process = new Process(OS::isOnWindows() ? ['php', 'phpunit-watcher'] : ['./phpunit-watcher']);

--- a/tests/WatcherCommandTest.php
+++ b/tests/WatcherCommandTest.php
@@ -8,7 +8,6 @@ use Spatie\PhpUnitWatcher\WatcherCommand;
 
 class WatcherCommandTest extends TestCase
 {
-    /** @test */
     #[Test]
     public function it_can_be_instantiated()
     {

--- a/tests/WatcherCommandTest.php
+++ b/tests/WatcherCommandTest.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\PhpUnitWatcher\Test;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Spatie\PhpUnitWatcher\WatcherCommand;
 
 class WatcherCommandTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $command = new WatcherCommand();

--- a/tests/WatcherFactoryTest.php
+++ b/tests/WatcherFactoryTest.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\PhpUnitWatcher\Test;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Spatie\PhpUnitWatcher\WatcherFactory;
 
 class WatcherFactoryTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $factory = new WatcherFactory();
@@ -16,6 +18,7 @@ class WatcherFactoryTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function setting_notification_preserves_other_options()
     {
         $userOptions = [
@@ -33,6 +36,7 @@ class WatcherFactoryTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function setting_directories_preserves_other_options()
     {
         $userOptions = [

--- a/tests/WatcherFactoryTest.php
+++ b/tests/WatcherFactoryTest.php
@@ -8,7 +8,6 @@ use Spatie\PhpUnitWatcher\WatcherFactory;
 
 class WatcherFactoryTest extends TestCase
 {
-    /** @test */
     #[Test]
     public function it_can_be_instantiated()
     {
@@ -17,7 +16,6 @@ class WatcherFactoryTest extends TestCase
         $this->assertInstanceOf(WatcherFactory::class, $factory);
     }
 
-    /** @test */
     #[Test]
     public function setting_notification_preserves_other_options()
     {
@@ -35,7 +33,6 @@ class WatcherFactoryTest extends TestCase
         $this->assertSame('*.php', $actualOptions['watch']['fileMask']);
     }
 
-    /** @test */
     #[Test]
     public function setting_directories_preserves_other_options()
     {


### PR DESCRIPTION
Resolves #159
Update Symfony dependencies to v7.
Update PHP Unit to V11

Note:
To be able to install in a project with `symfony/finder` v7 as a dep you need to update `yosymfony/resource-watcher`.
Unfortunately, this package has not been updated for 4 years even though a [PR](https://github.com/yosymfony/resource-watcher/pull/12) already exists for some of these updates. I've created my own fork to overcome this issue.
To use the fork add the repo entry to your composer.json, this will allow you to install the updated version `3.1.0`
```
"repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/michaelw85/resource-watcher"
        },
]
```