### PR TITLE
refactor: merge yosymfony/resource-watcher

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0]
+        php: [8.3, 8.2, 8.1, 8.0]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ build
 composer.lock
 vendor
 .phpunit.result.cache
+.phpunit.cache
 .php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/console": "<5.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.0"
+        "phpunit/phpunit": "^8.6 | ^9.0 | ^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": "^7.2 | ^8.0 | ^8.1",
+        "php": "^7.2 | ^8.0",
         "clue/stdio-react": "^2.4",
         "jolicode/jolinotif": "^2.2",
-        "symfony/console": "^5 | ^6",
-        "symfony/finder": "^5.4 | ^6",
-        "symfony/process": "^5.4 | ^6",
-        "symfony/yaml": "^5.2 | ^6",
+        "symfony/console": "^5 | ^6 | ^7",
+        "symfony/finder": "^5.4 | ^6 | ^7",
+        "symfony/process": "^5.4 | ^6 | ^7",
+        "symfony/yaml": "^5.2 | ^6 | ^7",
         "yosymfony/resource-watcher": "^2.0 | ^3.0"
     },
     "conflict": {
@@ -30,7 +30,7 @@
         "symfony/console": "<5.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.6 | ^9.0"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,21 +16,20 @@
         }
     ],
     "require": {
-        "php": "^7.2 | ^8.0",
+        "php": "^8.1",
         "clue/stdio-react": "^2.4",
         "jolicode/jolinotif": "^2.2",
-        "symfony/console": "^5 | ^6 | ^7",
-        "symfony/finder": "^5.4 | ^6 | ^7",
-        "symfony/process": "^5.4 | ^6 | ^7",
-        "symfony/yaml": "^5.2 | ^6 | ^7",
-        "yosymfony/resource-watcher": "^2.0 | ^3.0"
+        "symfony/console": "^6 | ^7",
+        "symfony/finder": "^6 | ^7",
+        "symfony/process": "^6 | ^7",
+        "symfony/yaml": "^6 | ^7"
     },
     "conflict": {
-        "yosymfony/resource-watcher": "<2.0",
         "symfony/console": "<5.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.6 | ^9.0 | ^11.0"
+        "symfony/filesystem": "^6 | ^7",
+        "phpunit/phpunit": "^10.0 | ^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="Spatie Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+    <coverage/>
+    <testsuites>
+        <testsuite name="Spatie Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/ConsoleApplication.php
+++ b/src/ConsoleApplication.php
@@ -13,7 +13,7 @@ class ConsoleApplication extends Application
         $this->add(new WatcherCommand());
     }
 
-    public function getLongVersion()
+    public function getLongVersion(): string
     {
         return parent::getLongVersion().' by <comment>Spatie</comment>';
     }

--- a/src/ResourceWatcher/Crc32ContentHash.php
+++ b/src/ResourceWatcher/Crc32ContentHash.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher;
+
+/**
+ * CRC32 content hash implementation.
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+ */
+class Crc32ContentHash implements HashInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function hash($filepath)
+    {
+        $fileContent = $filepath;
+
+        if (!\is_dir($filepath)) {
+            $fileContent = file_get_contents($filepath);
+        }
+
+        return hash('crc32', $fileContent);
+    }
+}

--- a/src/ResourceWatcher/Crc32MetaDataHash.php
+++ b/src/ResourceWatcher/Crc32MetaDataHash.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher;
+
+/**
+ * CRC32 content hash implementation.
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+ */
+class Crc32MetaDataHash implements HashInterface
+{
+    /** @var bool */
+    protected $clearStatCache;
+
+    /**
+     * Assign option to clear the file stat() cache.
+     * @param bool $clearStatCache
+     */
+    public function __construct($clearStatCache = false)
+    {
+        $this->clearStatCache = $clearStatCache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hash($filepath)
+    {
+        if ($this->clearStatCache) {
+            clearstatcache(true, $filepath);
+        }
+
+        $data = stat($filepath);
+
+        $str = basename($filepath) . $data['size'] . $data['mtime'] . $data['mode'];
+
+        return hash('crc32', $str);
+    }
+}

--- a/src/ResourceWatcher/HashInterface.php
+++ b/src/ResourceWatcher/HashInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher;
+
+/**
+ * Interface for hashing a file.
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+ */
+interface HashInterface
+{
+    /**
+     * Calculates the hash of a file.
+     *
+     * @param string $filepath
+     *
+     * @return string Returns a string containing the calculated message digest.
+     */
+    public function hash($filepath);
+}

--- a/src/ResourceWatcher/ResourceCacheInterface.php
+++ b/src/ResourceWatcher/ResourceCacheInterface.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher;
+
+/**
+ * Interface of a resource cache.
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+ */
+interface ResourceCacheInterface
+{
+    /**
+     * If the cache Initialized? if not then warm-up cache.
+     *
+     * @return bool
+     */
+    public function isInitialized();
+
+    /**
+     * Returns the hash of a file in cache.
+     *
+     * @param string $filename
+     *
+     * @return string The hash for the filename. Empty string if not exists.
+     */
+    public function read($filename);
+
+    /**
+     * Updates the hash of a file in cache.
+     *
+     * @param string $filename
+     * @param string $hash The calculated hash for the filename.
+     */
+    public function write($filename, $hash);
+
+    /**
+     * Deletes a file in cache.
+     *
+     * @param string $filename
+     *
+     * @return void
+     */
+    public function delete($filename);
+
+    /**
+     * Erases all the elements in cache.
+     *
+     * @return void
+     */
+    public function erase();
+
+    /**
+     * Returns all the element in cache.
+     *
+     * @return array A key-value array in which the key is the filename and the value is the hash.
+     */
+    public function getAll();
+
+    /**
+     * Persists the cache
+     *
+     * @return void
+     */
+    public function save();
+}

--- a/src/ResourceWatcher/ResourceCacheMemory.php
+++ b/src/ResourceWatcher/ResourceCacheMemory.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher;
+
+/**
+ * Resource cache implementation using memory.
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+ */
+class ResourceCacheMemory implements ResourceCacheInterface
+{
+    protected $isInitialized = false;
+    private $data = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isInitialized()
+    {
+        return $this->isInitialized;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($filename)
+    {
+        return isset($this->data[$filename]) ? $this->data[$filename] : '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($filename, $hash)
+    {
+        $this->data[$filename] = $hash;
+        $this->isInitialized = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($filename)
+    {
+        unset($this->data[$filename]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function erase()
+    {
+        $this->data = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAll()
+    {
+        return $this->data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save()
+    {
+        $this->isInitialized = true;
+    }
+}

--- a/src/ResourceWatcher/ResourceCachePhpFile.php
+++ b/src/ResourceWatcher/ResourceCachePhpFile.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher;
+
+/**
+ * Resource cache implementation using a PHP file with an array.
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+ */
+class ResourceCachePhpFile extends ResourceCacheMemory
+{
+    protected $filename;
+    protected $hasPendingChasges = false;
+
+    /**
+     * Constructor.
+     *
+     * @param string $filename The cache ".PHP" file. E.g: "resource-watcher-cache.php"
+     */
+    public function __construct($filename)
+    {
+        $this->filename = $filename;
+        $this->warmUpCacheFromFile($this->filename);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($filename, $hash)
+    {
+        if ($hash === $this->read($filename)) {
+            return;
+        }
+
+        parent::write($filename, $hash);
+
+        $this->hasPendingChasges = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save()
+    {
+        if ($this->hasPendingChasges === false) {
+            return;
+        }
+
+        $content = $this->composeContentCacheFile($this->getAll());
+
+        if (@file_put_contents($this->filename, $content) === false) {
+            throw new \RuntimeException(sprintf('Failed to write the cache file "%s".', $this->filename));
+        }
+
+        $this->hasPendingChasges = false;
+        $this->isInitialized = true;
+    }
+
+    /**
+     * @param string $filename
+     *
+     * @return void
+     */
+    private function warmUpCacheFromFile($filename)
+    {
+        if (preg_match('#\.php$#', $filename) == false) {
+            throw new \InvalidArgumentException('The cache filename must ends with the extension ".php".');
+        }
+
+        if (file_exists($filename) == false) {
+            $this->hasPendingChasges = true;
+
+            return;
+        }
+
+        $fileContent = include($filename);
+
+        if (is_array($fileContent) == false) {
+            throw new \InvalidArgumentException('Cache file invalid format.');
+        }
+
+        foreach ($fileContent as $filename => $hash) {
+            $this->write($filename, $hash);
+        }
+
+        $this->isInitialized = true;
+    }
+
+    /**
+     * @return string
+     */
+    private function composeContentCacheFile(array $cacheEntries)
+    {
+        $data = '';
+
+        foreach ($cacheEntries as $filename => $hash) {
+            $data .= sprintf("'%s'=>'%s',", $filename, $hash);
+        }
+
+        return "<?php\nreturn [$data];";
+    }
+}

--- a/src/ResourceWatcher/ResourceWatcher.php
+++ b/src/ResourceWatcher/ResourceWatcher.php
@@ -1,0 +1,222 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo as FinderFileInfo;
+
+/**
+ * A simple resource-watcher to discover changes in the filesystem.
+ * This component uses Symfony Finder to set the file search criteria.
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+ */
+class ResourceWatcher
+{
+    private $isEnabledRelativePath = false;
+    private $cache;
+    private $finder;
+    private $hasher;
+    private $fileHashesFromFinder = [];
+    private $newFiles = [];
+    private $deletedFiles = [];
+    private $updatedFiles = [];
+
+    /**
+     * Constructor.
+     *
+     * @param ResourceCacheInterface $resourceCache The cache.
+     * @param Finder $finder The Symfony Finder.
+     * @param HashInterface $hasher The file hash strategy.
+     */
+    public function __construct(ResourceCacheInterface $resourceCache, Finder $finder, HashInterface $hasher)
+    {
+        $this->cache = $resourceCache;
+        $this->finder = $finder;
+        $this->hasher = $hasher;
+    }
+
+    /**
+     * Initializes the resource watcher.
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+        if ($this->cache->isInitialized() == false) {
+            $this->findChanges();
+        }
+    }
+
+    /**
+     * Uses relative path with the resource cache.
+     *
+     * @return void
+     */
+    public function enableRelativePathWithCache()
+    {
+        $this->isEnabledRelativePath = true;
+    }
+
+    /**
+     * Finds all the changes in the filesystem according to the finder criteria.
+     *
+     * @return ResourceWatcherResult
+     */
+    public function findChanges()
+    {
+        $this->reset();
+
+        if ($this->cache->isInitialized() == false) {
+            $this->warmUpCache();
+        } else {
+            $this->findChangesAgainstCache();
+        }
+
+        $this->cache->save();
+
+        return new ResourceWatcherResult($this->newFiles, $this->deletedFiles, $this->updatedFiles);
+    }
+
+    /**
+     * Rebuilds the resource cache
+     *
+     * @return void
+     */
+    public function rebuild()
+    {
+        $this->cache->erase();
+        $this->reset();
+        $this->warmUpCache();
+        $this->cache->save();
+    }
+
+    /**
+     * @return void
+     */
+    private function reset()
+    {
+        $this->newFiles = [];
+        $this->deletedFiles = [];
+        $this->updatedFiles = [];
+    }
+
+    /**
+     * @return void
+     */
+    private function warmUpCache()
+    {
+        foreach ($this->finder as $file) {
+            $filePath = $file->getPathname();
+            $filePathForCache = $this->getFilePathForCache($file);
+            $this->cache->write($filePathForCache, $this->calculateHashOfFile($filePath));
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function findChangesAgainstCache()
+    {
+        $this->calculateHashOfFilesFromFinder();
+
+        $finderFileHashes = $this->fileHashesFromFinder;
+        $cacheFileHashes = $this->cache->getAll();
+
+        if (count($finderFileHashes) > count($cacheFileHashes)) {
+            foreach ($finderFileHashes as $file => $hash) {
+                $this->processFileFromFilesystem($file, $hash);
+            }
+        } else {
+            foreach ($cacheFileHashes as $file => $hash) {
+                $this->processFileFromCache($file, $hash);
+            }
+        }
+    }
+
+    /**
+     * @param string $file
+     * @param string $hash
+     *
+     * @return void
+     */
+    private function processFileFromFilesystem($file, $hash)
+    {
+        $hashFromCache = $this->cache->read($file);
+
+        if ($hashFromCache) {
+            if ($hash != $hashFromCache) {
+                $this->cache->write($file, $hash);
+                $this->updatedFiles[] = $file;
+            }
+        } else {
+            $this->cache->write($file, $hash);
+            $this->newFiles[] = $file;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function processFileFromCache($file, $hash)
+    {
+        $hashFromCache = isset($this->fileHashesFromFinder[$file]) ? $this->fileHashesFromFinder[$file] : null;
+
+        if ($hashFromCache) {
+            if ($hashFromCache != $hash) {
+                $this->cache->write($file, $hashFromCache);
+                $this->updatedFiles[] = $file;
+            }
+        } else {
+            $this->cache->delete($file);
+            $this->deletedFiles[] = $file;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function calculateHashOfFilesFromFinder()
+    {
+        $pathsAndHashes = [];
+
+        foreach ($this->finder as $file) {
+            $filePath = $file->getPathname();
+            $filePathForCache = $this->getFilePathForCache($file);
+            $pathsAndHashes[$filePathForCache] = $this->calculateHashOfFile($filePath);
+        }
+
+        $this->fileHashesFromFinder = $pathsAndHashes;
+    }
+
+    /**
+     * @param $filename
+     * @return string
+     */
+    private function calculateHashOfFile($filename)
+    {
+        return $this->hasher->hash($filename);
+    }
+
+    /**
+     * @param FinderFileInfo $file
+     * @return string
+     */
+    private function getFilePathForCache(FinderFileInfo $file)
+    {
+        if ($this->isEnabledRelativePath === true) {
+            return $file->getRelativePathname();
+        }
+
+        return $file->getPathname();
+    }
+}

--- a/src/ResourceWatcher/ResourceWatcherResult.php
+++ b/src/ResourceWatcher/ResourceWatcherResult.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * A Resource Watcher result with the filesystem changes.
+ *
+ * @author Victor Puertas <vpgugr@gmail.com>
+ */
+class ResourceWatcherResult
+{
+    private $hasChanges;
+    private $newResources;
+    private $deletedResources;
+    private $updatedResources;
+
+    /**
+     * Constructor.
+     */
+    public function __construct(array $newResources, array $deletedResources, array $updatedResources)
+    {
+        $this->newResources = $newResources;
+        $this->deletedResources = $deletedResources;
+        $this->updatedResources = $updatedResources;
+    }
+    /**
+     * Has any change in resources?
+     *
+     * @return bool
+     */
+    public function hasChanges()
+    {
+        if ($this->hasChanges) {
+            return $this->hasChanges;
+        }
+
+        $this->hasChanges = count($this->newResources) > 0 || count($this->deletedResources) > 0 || count($this->updatedResources) > 0;
+
+        return $this->hasChanges;
+    }
+
+    /**
+     * Returns an array with paths of the new resources ('.', '..' not resolved).
+     *
+     * @return array
+     */
+    public function getNewFiles()
+    {
+        return $this->newResources;
+    }
+
+    /**
+     * Returns an array with path of the deleted resources ('.', '..' not resolved).
+     *
+     * @return array
+     */
+    public function getDeletedFiles()
+    {
+        return $this->deletedResources;
+    }
+
+    /**
+     * Returns an array with path of the updated resources ('.', '..' not resolved).
+     *
+     * @return array
+     */
+    public function getUpdatedFiles()
+    {
+        return $this->updatedResources;
+    }
+}

--- a/src/Watcher.php
+++ b/src/Watcher.php
@@ -7,9 +7,9 @@ use React\EventLoop\Factory;
 use React\Stream\ThroughStream;
 use Spatie\PhpUnitWatcher\Screens\Phpunit;
 use Symfony\Component\Finder\Finder;
-use Yosymfony\ResourceWatcher\Crc32ContentHash;
-use Yosymfony\ResourceWatcher\ResourceCacheMemory;
-use Yosymfony\ResourceWatcher\ResourceWatcher;
+use Spatie\PhpUnitWatcher\ResourceWatcher\Crc32ContentHash;
+use Spatie\PhpUnitWatcher\ResourceWatcher\ResourceCacheMemory;
+use Spatie\PhpUnitWatcher\ResourceWatcher\ResourceWatcher;
 
 class Watcher
 {

--- a/src/WatcherCommand.php
+++ b/src/WatcherCommand.php
@@ -19,7 +19,7 @@ class WatcherCommand extends Command
             ->addArgument('phpunit-options', InputArgument::OPTIONAL, 'Options passed to phpunit');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $options = $this->determineOptions($input);
 
@@ -28,6 +28,8 @@ class WatcherCommand extends Command
         $this->displayOptions($options, $input, $output);
 
         $watcher->startWatching();
+
+        return 0;
     }
 
     protected function determineOptions(InputInterface $input): array

--- a/tests/PhpunitWatcherTest.php
+++ b/tests/PhpunitWatcherTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\Attributes\Test;
 
 class PhpunitWatcherTest extends TestCase
 {
-    /** @test */
     #[Test]
     public function the_watcher_can_be_executed()
     {

--- a/tests/PhpunitWatcherTest.php
+++ b/tests/PhpunitWatcherTest.php
@@ -5,10 +5,12 @@ namespace Spatie\PhpUnitWatcher\Test;
 use PHPUnit\Framework\TestCase;
 use Spatie\PhpUnitWatcher\OS;
 use Symfony\Component\Process\Process;
+use PHPUnit\Framework\Attributes\Test;
 
 class PhpunitWatcherTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function the_watcher_can_be_executed()
     {
         $process = new Process(OS::isOnWindows() ? ['php', 'phpunit-watcher'] : ['./phpunit-watcher']);

--- a/tests/ResourceWatcher/Crc32ContentHashTest.php
+++ b/tests/ResourceWatcher/Crc32ContentHashTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\PhpUnitWatcher\ResourceWatcher\Crc32ContentHash;
+
+class Crc32ContentHashTest extends TestCase
+{
+    public function testHashMustReturnTheContentDisgestWithCRC32()
+    {
+        $filepath = sys_get_temp_dir() . '/test.txt';
+
+        file_put_contents($filepath, 'acme');
+
+        $crc32ContentHash = new Crc32ContentHash();
+        $currentValue = $crc32ContentHash->hash($filepath);
+
+        $this->assertEquals('8f7ecb57', $currentValue);
+
+        unlink($filepath);
+    }
+}

--- a/tests/ResourceWatcher/Crc32MetaDataHashTest.php
+++ b/tests/ResourceWatcher/Crc32MetaDataHashTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\PhpUnitWatcher\ResourceWatcher\Crc32MetaDataHash;
+
+class Crc32MetaDataHashTest extends TestCase
+{
+    public function testHashMustReturnTheMetaDataDigestWithCRC32()
+    {
+        $filepath = sys_get_temp_dir() . '/test.txt';
+
+        touch($filepath, strtotime('2020-05-25 17:42'));
+
+        $crc32ContentHash = new Crc32MetaDataHash();
+        $currentValue = $crc32ContentHash->hash($filepath);
+
+        $fileData = stat($filepath);
+
+        $expected = basename($filepath) . $fileData['size'] . $fileData['mtime'] . $fileData['mode'];
+
+        $this->assertEquals(hash('crc32', $expected), $currentValue);
+
+        unlink($filepath);
+    }
+}

--- a/tests/ResourceWatcher/ResourceCacheMemoryTest.php
+++ b/tests/ResourceWatcher/ResourceCacheMemoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\PhpUnitWatcher\ResourceWatcher\ResourceCacheMemory;
+
+class ResourceCacheMemoryTest extends TestCase
+{
+    private $cache;
+
+    public function setUp(): void
+    {
+        $this->cache = new ResourceCacheMemory();
+    }
+
+    public function testIsInitializedMustReturnFalseInTheInitialState()
+    {
+        $this->assertFalse($this->cache->isInitialized());
+    }
+
+    public function testIsInitializedMustReturnTrueAfterSave()
+    {
+        $this->cache->save();
+
+        $this->assertTrue($this->cache->isInitialized());
+    }
+
+    public function testGetAllMustReturnAllFilesInCache()
+    {
+        $this->cache->write('/my-path/file1.txt', '2442345');
+
+        $this->assertCount(1, $this->cache->getAll());
+    }
+
+    public function testReadMustReturnTheHashOfTheFile()
+    {
+        $hash = 'a54ffa';
+        $this->cache->write('/my-path/file1.txt', $hash);
+
+        $this->assertEquals($hash, $this->cache->read('/my-path/file1.txt'));
+    }
+
+    public function testWriteMustAddANewFile()
+    {
+        $hash = 'a54ffa';
+        $this->cache->write('/my-path/file1.txt', $hash);
+
+        $this->assertEquals($hash, $this->cache->read('/my-path/file1.txt'));
+    }
+
+    public function testWriteMustUpdateAFilePreviouslyAdded()
+    {
+        $hash = 'b54ffb';
+        $file = '/my-path/file1.txt';
+        $this->cache->write($file, 'a54ffa');
+        $this->cache->write($file, $hash);
+
+        $this->assertEquals($hash, $this->cache->read('/my-path/file1.txt'));
+    }
+
+    public function testEraseMustDeleteAllFiles()
+    {
+        $this->cache->write('/my-path/file1.txt', 'a54ffa');
+        $this->cache->erase();
+
+        $this->assertCount(0, $this->cache->getAll());
+    }
+
+    public function testDeleteMustDeleteTheFileIndicated()
+    {
+        $file = '/my-path/file1.txt';
+        $this->cache->write($file, 'a54ffa');
+        $this->cache->delete($file);
+
+        $this->assertCount(0, $this->cache->getAll());
+    }
+}

--- a/tests/ResourceWatcher/ResourceCachePhpFileTest.php
+++ b/tests/ResourceWatcher/ResourceCachePhpFileTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Spatie\PhpUnitWatcher\ResourceWatcher\ResourceCachePhpFile;
+
+class ResourceCachePhpFileTest extends TestCase
+{
+    private $cacheFile;
+    private $fs;
+    private $tmpDir;
+
+    public function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/resource-watchers-tests';
+        $this->cacheFile = $this->tmpDir . '/cache-file-test.php';
+        $this->fs = new Filesystem();
+        $this->fs->mkdir($this->tmpDir);
+    }
+
+    public function tearDown(): void
+    {
+        $this->fs->remove($this->tmpDir);
+    }
+
+    public function testIsInitializedMustReturnFalseWhenTheCacheFileIsNotExists()
+    {
+        $resourceCache = new ResourceCachePhpFile($this->cacheFile);
+
+        $this->assertFalse($resourceCache->isInitialized());
+    }
+
+    public function testIsInitializedMustReturnTrueWhenTheCacheIsSavedInTheCacheFile()
+    {
+        $resourceCache = new ResourceCachePhpFile($this->cacheFile);
+        $resourceCache->save();
+
+        $this->assertTrue($resourceCache->isInitialized());
+    }
+
+    public function testIsInitializedMustReturnTrueWhenThereIsAValidCacheFile()
+    {
+        $this->fs->dumpFile($this->cacheFile, "<?php\nreturn [];");
+        $resourceCache = new ResourceCachePhpFile($this->cacheFile);
+
+        $this->assertTrue($resourceCache->isInitialized());
+    }
+
+    public function testSaveMustDumpTheContentCacheInAFile()
+    {
+        $resourceCache = new ResourceCachePhpFile($this->cacheFile);
+        $filename = 'file1.md';
+        $hash = '23998C';
+        $resourceCache->write($filename, $hash);
+        $resourceCache->save();
+
+        $fileContent = file_get_contents($this->cacheFile);
+
+        $this->assertEquals($fileContent, "<?php\nreturn ['$filename'=>'$hash',];");
+    }
+
+    public function testConstructWithAInvalidCacheFileMustThrownAnException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cache file invalid format.');
+        $this->fs->dumpFile($this->cacheFile, '');
+
+        $rc = new ResourceCachePhpFile($this->cacheFile);
+    }
+
+    public function testConstructWithANoPhpFileExtensionMustThrownAnException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The cache filename must ends with the extension ".php".');
+        $rc = new ResourceCachePhpFile($this->tmpDir . '/cache-file-test.txt');
+    }
+}

--- a/tests/ResourceWatcher/ResourceWatcherResultTest.php
+++ b/tests/ResourceWatcher/ResourceWatcherResultTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\PhpUnitWatcher\ResourceWatcher\ResourceWatcherResult;
+
+class ResourceWatcherResultTest extends TestCase
+{
+    private $newFiles;
+    private $deletedFiles;
+    private $updatedFiles;
+    private $resourceWatcherResult;
+
+    public function setUp(): void
+    {
+        $this->newFiles = ['/my-path/newfile.txt'];
+        $this->deletedFiles = ['/my-path/deletedfile.txt'];
+        $this->updatedFiles = ['/my-path/updatedfile.txt'];
+        $this->resourceWatcherResult = new ResourceWatcherResult(
+            $this->newFiles,
+            $this->deletedFiles,
+            $this->updatedFiles
+        );
+    }
+
+    public function testHasChangesMustReturnTrueWhenExistsNewFiles()
+    {
+        $resourceWatcherResult = new ResourceWatcherResult($this->newFiles, [], []);
+
+        $this->assertTrue($resourceWatcherResult->hasChanges());
+    }
+
+    public function testHasChangesMustReturnTrueWhenExistsDeletedFiles()
+    {
+        $resourceWatcherResult = new ResourceWatcherResult([], $this->deletedFiles, []);
+
+        $this->assertTrue($resourceWatcherResult->hasChanges());
+    }
+
+    public function testHasChangesMustReturnTrueWhenExistsUpdatedFiles()
+    {
+        $resourceWatcherResult = new ResourceWatcherResult([], [], $this->updatedFiles);
+
+        $this->assertTrue($resourceWatcherResult->hasChanges());
+    }
+
+    public function testHasChangesMustReturnFalseWhenDoesNotExistsChanges()
+    {
+        $resourceWatcherResult = new ResourceWatcherResult([], [], []);
+
+        $this->assertFalse($resourceWatcherResult->hasChanges());
+    }
+
+    public function testGetNewFilesMustReturnTheNewFiles()
+    {
+        $files = $this->resourceWatcherResult->getNewFiles();
+        $this->assertCount(1, $files);
+        $this->assertEquals('/my-path/newfile.txt', $files[0]);
+    }
+
+    public function testGetDeletedFilesMustReturnTheDeletedFiles()
+    {
+        $files = $this->resourceWatcherResult->getDeletedFiles();
+        $this->assertCount(1, $files);
+        $this->assertEquals('/my-path/deletedfile.txt', $files[0]);
+    }
+
+    public function testGetUpdatedFilesMustReturnTheDeletedFiles()
+    {
+        $files = $this->resourceWatcherResult->getUpdatedFiles();
+        $this->assertCount(1, $files);
+        $this->assertEquals('/my-path/updatedfile.txt', $files[0]);
+    }
+}

--- a/tests/ResourceWatcher/ResourceWatcherTest.php
+++ b/tests/ResourceWatcher/ResourceWatcherTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * This file is part of the Yo! Symfony Resource Watcher.
+ *
+ * (c) YoSymfony <http://github.com/yosymfony>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Spatie\PhpUnitWatcher\ResourceWatcher\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Spatie\PhpUnitWatcher\ResourceWatcher\Crc32ContentHash;
+use Spatie\PhpUnitWatcher\ResourceWatcher\ResourceWatcher;
+use Spatie\PhpUnitWatcher\ResourceWatcher\ResourceCacheMemory;
+
+class ResourceWatcherTest extends TestCase
+{
+    protected $tmpDir;
+    protected $fs;
+
+    public function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/resourceWatcher-tests';
+        $this->fs = new Filesystem();
+
+        $this->fs->mkdir($this->tmpDir);
+    }
+
+    public function tearDown(): void
+    {
+        $this->fs->remove($this->tmpDir);
+    }
+
+    public function testInitializeMustWarmUpTheCacheInCaseItIsCold()
+    {
+        $finder = new Finder();
+        $finder->files()
+            ->name('*.txt')
+            ->in($this->tmpDir);
+        $cacheMemory = new ResourceCacheMemory();
+        $contentHashCrc32 = new Crc32ContentHash();
+        $resourceWatcher = new ResourceWatcher($cacheMemory, $finder, $contentHashCrc32);
+        $resourceWatcher->initialize();
+
+        $this->assertTrue($cacheMemory->isInitialized());
+    }
+
+    public function testHasChangesMustReturnFalseWithColdCache()
+    {
+        $finder = new Finder();
+        $finder->files()
+            ->name('*.txt')
+            ->in($this->tmpDir);
+        $resourceWatcher = $this->makeResourceWatcher($finder);
+
+        $result = $resourceWatcher->findChanges();
+
+        $this->assertFalse($result->hasChanges());
+    }
+
+    public function testHasChangesMustReturnTrueWhenNewFile()
+    {
+        $finder = new Finder();
+        $finder->files()
+            ->name('*.txt')
+            ->in($this->tmpDir);
+        $resourceWatcher = $this->makeResourceWatcher($finder);
+
+        $resourceWatcher->findChanges();
+        $this->fs->dumpFile($this->tmpDir . '/file1.txt', 'test');
+        $result = $resourceWatcher->findChanges();
+
+        $this->assertTrue($result->hasChanges());
+    }
+
+    public function testHasChangesMustReturnFalseAfterRebuildCache()
+    {
+        $finder = new Finder();
+        $finder->files()
+            ->name('*.txt')
+            ->in($this->tmpDir);
+        $resourceWatcher = $this->makeResourceWatcher($finder);
+
+        $resourceWatcher->findChanges();
+        $this->fs->dumpFile($this->tmpDir . '/file1.txt', 'test');
+        $resourceWatcher->rebuild();
+        $result = $resourceWatcher->findChanges();
+
+        $this->assertFalse($result->hasChanges());
+    }
+
+    public function testFindChangesMustReturnANewFileWhenItIsCreated()
+    {
+        $finder = new Finder();
+        $finder->files()
+            ->name('*.txt')
+            ->in($this->tmpDir);
+        $resourceWatcher = $this->makeResourceWatcher($finder);
+
+        $resourceWatcher->findChanges();
+        $this->fs->dumpFile($this->tmpDir . '/file1.txt', 'test');
+        $result = $resourceWatcher->findChanges();
+
+        $this->assertCount(1, $result->getNewFiles());
+    }
+
+    public function testFindChangesMustReturnADeletedFileWhenItIsDeleted()
+    {
+        $finder = new Finder();
+        $finder->files()
+            ->name('*.txt')
+            ->in($this->tmpDir);
+        $resourceWatcher = $this->makeResourceWatcher($finder);
+
+        $this->fs->dumpFile($this->tmpDir . '/file1.txt', 'test');
+        $resourceWatcher->findChanges();
+        $this->fs->remove($this->tmpDir . '/file1.txt');
+        $result = $resourceWatcher->findChanges();
+
+        $this->assertCount(1, $result->getDeletedFiles());
+    }
+
+    public function testFindChangesMustReturnAUpdatedFileWhenItIsModified()
+    {
+        $filename = $this->tmpDir . '/file1.txt';
+        $finder = new Finder();
+        $finder->files()
+            ->name('*.txt')
+            ->in($this->tmpDir);
+        $resourceWatcher = $this->makeResourceWatcher($finder);
+
+        $this->fs->dumpFile($filename, 'test');
+        $resourceWatcher->findChanges();
+        @file_put_contents($filename, 'update1', \FILE_APPEND);
+        $result = $resourceWatcher->findChanges();
+
+        $this->assertCount(1, $result->getUpdatedFiles());
+    }
+
+    public function testFindChangesMustReturnANewFileWhenANewDirectoryIsCreated()
+    {
+        $finder = new Finder();
+        $finder->in($this->tmpDir);
+        $resourceWatcher = $this->makeResourceWatcher($finder);
+
+        $resourceWatcher->findChanges();
+        $this->fs->mkdir($this->tmpDir . '/dir-test');
+        $result = $resourceWatcher->findChanges();
+        $newFiles = $result->getNewFiles();
+
+        $this->assertCount(1, $newFiles);
+        $this->assertEquals($this->tmpDir . '/dir-test', $newFiles[0]);
+    }
+
+    public function testFindChangesMustUsesTheRelativePathWithTheCacheWhenEnableRelativePath()
+    {
+        $filename = 'file1.txt';
+        $file = $this->tmpDir . '/'.$filename;
+        $cacheMemory = new ResourceCacheMemory();
+        $contentHashCrc32 = new Crc32ContentHash();
+        $this->fs->dumpFile($file, 'test');
+        $finder = new Finder();
+        $finder->in($this->tmpDir);
+        $finder->files();
+
+        $resourceWatcher = new ResourceWatcher($cacheMemory, $finder, $contentHashCrc32);
+        $resourceWatcher->enableRelativePathWithCache();
+        $resourceWatcher->initialize();
+
+        $this->assertTrue(\strlen($cacheMemory->read($filename)) > 0);
+        $this->assertTrue(\strlen($cacheMemory->read($file)) == 0);
+    }
+
+    public function testFindChangesMustUsesThePathWithTheCacheWhenIsNotEnabledTheRelativePath()
+    {
+        $filename = 'file1.txt';
+        $file = $this->tmpDir . '/'.$filename;
+        $cacheMemory = new ResourceCacheMemory();
+        $contentHashCrc32 = new Crc32ContentHash();
+        $this->fs->dumpFile($file, 'test');
+        $finder = new Finder();
+        $finder->in($this->tmpDir);
+        $finder->files();
+
+        $resourceWatcher = new ResourceWatcher($cacheMemory, $finder, $contentHashCrc32);
+        $resourceWatcher->initialize();
+
+        $this->assertTrue(\strlen($cacheMemory->read($filename)) == 0);
+        $this->assertTrue(\strlen($cacheMemory->read($file)) > 0);
+    }
+
+    private function makeResourceWatcher(Finder $finder)
+    {
+        $cacheMemory = new ResourceCacheMemory();
+        $contentHashCrc32 = new Crc32ContentHash();
+
+        return new ResourceWatcher($cacheMemory, $finder, $contentHashCrc32);
+    }
+}

--- a/tests/WatcherCommandTest.php
+++ b/tests/WatcherCommandTest.php
@@ -8,7 +8,6 @@ use Spatie\PhpUnitWatcher\WatcherCommand;
 
 class WatcherCommandTest extends TestCase
 {
-    /** @test */
     #[Test]
     public function it_can_be_instantiated()
     {

--- a/tests/WatcherCommandTest.php
+++ b/tests/WatcherCommandTest.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\PhpUnitWatcher\Test;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Spatie\PhpUnitWatcher\WatcherCommand;
 
 class WatcherCommandTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $command = new WatcherCommand();

--- a/tests/WatcherFactoryTest.php
+++ b/tests/WatcherFactoryTest.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\PhpUnitWatcher\Test;
 
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Spatie\PhpUnitWatcher\WatcherFactory;
 
 class WatcherFactoryTest extends TestCase
 {
     /** @test */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $factory = new WatcherFactory();
@@ -16,6 +18,7 @@ class WatcherFactoryTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function setting_notification_preserves_other_options()
     {
         $userOptions = [
@@ -33,6 +36,7 @@ class WatcherFactoryTest extends TestCase
     }
 
     /** @test */
+    #[Test]
     public function setting_directories_preserves_other_options()
     {
         $userOptions = [

--- a/tests/WatcherFactoryTest.php
+++ b/tests/WatcherFactoryTest.php
@@ -8,7 +8,6 @@ use Spatie\PhpUnitWatcher\WatcherFactory;
 
 class WatcherFactoryTest extends TestCase
 {
-    /** @test */
     #[Test]
     public function it_can_be_instantiated()
     {
@@ -17,7 +16,6 @@ class WatcherFactoryTest extends TestCase
         $this->assertInstanceOf(WatcherFactory::class, $factory);
     }
 
-    /** @test */
     #[Test]
     public function setting_notification_preserves_other_options()
     {
@@ -35,7 +33,6 @@ class WatcherFactoryTest extends TestCase
         $this->assertSame('*.php', $actualOptions['watch']['fileMask']);
     }
 
-    /** @test */
     #[Test]
     public function setting_directories_preserves_other_options()
     {


### PR DESCRIPTION
Include `yosymfony/resource-watcher` directly in PHPUnit watcher so that it is easier to manage dependencies.